### PR TITLE
[POC]  Enhance the ray object store with more functionalities.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -296,6 +296,7 @@ cc_library(
     name = "plasma_client",
     srcs = [
         "src/ray/object_manager/plasma/client.cc",
+        "src/ray/object_manager/plasma/vineyard_client_impl.cc",
         "src/ray/object_manager/plasma/connection.cc",
         "src/ray/object_manager/plasma/malloc.cc",
         "src/ray/object_manager/plasma/plasma.cc",
@@ -311,6 +312,7 @@ cc_library(
     hdrs = [
         "src/ray/object_manager/common.h",
         "src/ray/object_manager/plasma/client.h",
+        "src/ray/object_manager/plasma/vineyard_client_impl.h",
         "src/ray/object_manager/plasma/common.h",
         "src/ray/object_manager/plasma/compat.h",
         "src/ray/object_manager/plasma/connection.h",
@@ -326,12 +328,12 @@ cc_library(
             "src/ray/object_manager/plasma/fling.h",
         ],
     }),
-    copts = PLASMA_COPTS,
+    copts = PLASMA_COPTS + ["-I/usr/local/include/vineyard"],
     defines = select({
         "@bazel_tools//src/conditions:windows": PROPAGATED_WINDOWS_DEFINES,
         "//conditions:default": [],
     }),
-    linkopts = PLASMA_LINKOPTS,
+    linkopts = PLASMA_LINKOPTS + ["-L/usr/local/lib/", "-lvineyard_client", "-lvineyard_basic"],
     strip_include_prefix = "src",
     deps = [
         ":plasma_fbs",

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -113,6 +113,7 @@ Status CoreWorkerPlasmaStoreProvider::Create(const std::shared_ptr<Buffer> &meta
   if (!created_by_worker) {
     source = plasma::flatbuf::ObjectSource::RestoredFromStorage;
   }
+  RAY_LOG(INFO) << "MENGKE: create" << object_id << "in provider metasize"  <<  (metadata ? metadata->Size() : 0) << " data_size :" << data_size ;
   Status status = store_client_.CreateAndSpillIfNeeded(
       object_id, owner_address, data_size, metadata ? metadata->Data() : nullptr,
       metadata ? metadata->Size() : 0, data, source,

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -306,7 +306,6 @@ Status PlasmaClientImpl::CreateAndSpillIfNeeded(
 
   RAY_LOG(DEBUG) << "called plasma_create on conn " << store_conn_ << " with size "
                  << data_size << " and metadata size " << metadata_size;
-  RAY_LOG(INFO) << " MENGKE: metadata size when Create: " << metadata_size;
   RAY_RETURN_NOT_OK(SendCreateRequest(store_conn_, object_id, owner_address, data_size,
                                       metadata_size, source, device_num,
                                       /*try_immediately=*/false));
@@ -355,18 +354,15 @@ Status PlasmaClientImpl::GetBuffers(
     const std::function<std::shared_ptr<Buffer>(
         const ObjectID &, const std::shared_ptr<Buffer> &)> &wrap_buffer,
     ObjectBuffer *object_buffers, bool is_from_worker) {
-  RAY_LOG(INFO) << "MENGKE: try to get Buffer ";
   // Fill out the info for the objects that are already in use locally.
   bool all_present = true;
   for (int64_t i = 0; i < num_objects; ++i) {
     auto object_entry = objects_in_use_.find(object_ids[i]);
     if (object_entry == objects_in_use_.end()) {
-      RAY_LOG(INFO) << "MENGKE: GET no in use: ";
       // This object is not currently in use by this client, so we need to send
       // a request to the store.
       all_present = false;
     } else if (!object_entry->second->is_sealed) {
-      RAY_LOG(INFO) << "MENGKE: GET not sealed: ";
       // This client created the object but hasn't sealed it. If we call Get
       // with no timeout, we will deadlock, because this client won't be able to
       // call Seal.
@@ -446,7 +442,6 @@ Status PlasmaClientImpl::GetBuffers(
       } else {
         RAY_LOG(FATAL) << "Arrow GPU library is not enabled.";
       }
-      RAY_LOG(INFO) << "MENGKE: metadata size when GET: " << object->metadata_size;
       // Finish filling out the return values.
       physical_buf = wrap_buffer(object_ids[i], physical_buf);
       object_buffers[i].data =
@@ -638,7 +633,6 @@ Status PlasmaClientImpl::Connect(const std::string &store_socket_name,
                                  const std::string &manager_socket_name,
                                  int release_delay, int num_retries) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
-  RAY_LOG(INFO) << "MENGKE: " << store_socket_name;
 
   /// The local stream socket that connects to store.
   ray::local_stream_socket socket(main_service_);

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -47,6 +47,8 @@ namespace plasma {
 using fb::MessageType;
 using fb::PlasmaError;
 
+class PlasmaClientImpl;
+
 // ----------------------------------------------------------------------
 // PlasmaBuffer
 
@@ -56,14 +58,14 @@ class PlasmaBuffer : public SharedMemoryBuffer {
  public:
   ~PlasmaBuffer();
 
-  PlasmaBuffer(std::shared_ptr<PlasmaClient::Impl> client, const ObjectID &object_id,
+  PlasmaBuffer(std::shared_ptr<PlasmaClientImpl> client, const ObjectID &object_id,
                const std::shared_ptr<Buffer> &buffer)
       : SharedMemoryBuffer(buffer, 0, buffer->Size()),
         client_(client),
         object_id_(object_id) {}
 
  private:
-  std::shared_ptr<PlasmaClient::Impl> client_;
+  std::shared_ptr<PlasmaClientImpl> client_;
   ObjectID object_id_;
 };
 
@@ -72,16 +74,16 @@ class PlasmaBuffer : public SharedMemoryBuffer {
 /// be called in the associated Seal call.
 class RAY_NO_EXPORT PlasmaMutableBuffer : public SharedMemoryBuffer {
  public:
-  PlasmaMutableBuffer(std::shared_ptr<PlasmaClient::Impl> client, uint8_t *mutable_data,
+  PlasmaMutableBuffer(std::shared_ptr<PlasmaClientImpl> client, uint8_t *mutable_data,
                       int64_t data_size)
       : SharedMemoryBuffer(mutable_data, data_size), client_(client) {}
 
  private:
-  std::shared_ptr<PlasmaClient::Impl> client_;
+  std::shared_ptr<PlasmaClientImpl> client_;
 };
 
 // ----------------------------------------------------------------------
-// PlasmaClient::Impl
+// PlasmaClientImpl
 
 struct ObjectInUseEntry {
   /// A count of the number of times this client has called PlasmaClient::Create
@@ -97,60 +99,56 @@ struct ObjectInUseEntry {
   bool is_sealed;
 };
 
-class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Impl> {
+class PlasmaClientImpl : public IPlasmaClientImpl, 
+                         public std::enable_shared_from_this<PlasmaClientImpl> {
  public:
-  Impl();
-  ~Impl();
+  PlasmaClientImpl();
+  ~PlasmaClientImpl();
 
   // PlasmaClient method implementations
 
   Status Connect(const std::string &store_socket_name,
                  const std::string &manager_socket_name, int release_delay = 0,
-                 int num_retries = -1);
-
-  Status SetClientOptions(const std::string &client_name, int64_t output_memory_quota);
+                 int num_retries = -1) override;
 
   Status CreateAndSpillIfNeeded(const ObjectID &object_id,
                                 const ray::rpc::Address &owner_address, int64_t data_size,
                                 const uint8_t *metadata, int64_t metadata_size,
                                 std::shared_ptr<Buffer> *data, fb::ObjectSource source,
-                                int device_num = 0);
+                                int device_num = 0) override;
 
   Status RetryCreate(const ObjectID &object_id, uint64_t request_id,
                      const uint8_t *metadata, uint64_t *retry_with_request_id,
-                     std::shared_ptr<Buffer> *data);
+                     std::shared_ptr<Buffer> *data) override;
 
   Status TryCreateImmediately(const ObjectID &object_id,
                               const ray::rpc::Address &owner_address, int64_t data_size,
                               const uint8_t *metadata, int64_t metadata_size,
                               std::shared_ptr<Buffer> *data, fb::ObjectSource source,
-                              int device_num);
+                              int device_num) override;
 
   Status Get(const std::vector<ObjectID> &object_ids, int64_t timeout_ms,
-             std::vector<ObjectBuffer> *object_buffers, bool is_from_worker);
+             std::vector<ObjectBuffer> *object_buffers, bool is_from_worker) override;
 
-  Status Get(const ObjectID *object_ids, int64_t num_objects, int64_t timeout_ms,
-             ObjectBuffer *object_buffers, bool is_from_worker);
+  Status Release(const ObjectID &object_id) override;
 
-  Status Release(const ObjectID &object_id);
+  Status Contains(const ObjectID &object_id, bool *has_object) override;
 
-  Status Contains(const ObjectID &object_id, bool *has_object);
+  Status Abort(const ObjectID &object_id) override;
 
-  Status Abort(const ObjectID &object_id);
+  Status Seal(const ObjectID &object_id) override;
 
-  Status Seal(const ObjectID &object_id);
+  Status Delete(const std::vector<ObjectID> &object_ids) override;
 
-  Status Delete(const std::vector<ObjectID> &object_ids);
+  Status Evict(int64_t num_bytes, int64_t &num_bytes_evicted) override;
 
-  Status Evict(int64_t num_bytes, int64_t &num_bytes_evicted);
+  Status Disconnect() override;
 
-  Status Disconnect();
+  std::string DebugString() override;
 
-  std::string DebugString();
+  bool IsInUse(const ObjectID &object_id) override;
 
-  bool IsInUse(const ObjectID &object_id);
-
-  int64_t store_capacity() { return store_capacity_; }
+  int64_t store_capacity() override { return store_capacity_; }
 
  private:
   /// Helper method to read and process the reply of a create request.
@@ -161,7 +159,7 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
   /// Check if store_fd has already been received from the store. If yes,
   /// return it. Otherwise, receive it from the store (see analogous logic
   /// in store.cc).
-  ///
+///
   /// \param store_fd File descriptor to fetch from the store.
   /// \return The pointer corresponding to store_fd.
   uint8_t *GetStoreFdAndMmap(MEMFD_TYPE store_fd, int64_t map_size);
@@ -210,14 +208,14 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
 
 PlasmaBuffer::~PlasmaBuffer() { RAY_UNUSED(client_->Release(object_id_)); }
 
-PlasmaClient::Impl::Impl() : store_capacity_(0) {}
+PlasmaClientImpl::PlasmaClientImpl() : store_capacity_(0) {}
 
-PlasmaClient::Impl::~Impl() {}
+PlasmaClientImpl::~PlasmaClientImpl() {}
 
 // If the file descriptor fd has been mmapped in this client process before,
 // return the pointer that was returned by mmap, otherwise mmap it and store the
 // pointer in a hash table.
-uint8_t *PlasmaClient::Impl::GetStoreFdAndMmap(MEMFD_TYPE store_fd_val,
+uint8_t *PlasmaClientImpl::GetStoreFdAndMmap(MEMFD_TYPE store_fd_val,
                                                int64_t map_size) {
   auto entry = mmap_table_.find(store_fd_val);
   if (entry != mmap_table_.end()) {
@@ -239,20 +237,20 @@ uint8_t *PlasmaClient::Impl::GetStoreFdAndMmap(MEMFD_TYPE store_fd_val,
 
 // Get a pointer to a file that we know has been memory mapped in this client
 // process before.
-uint8_t *PlasmaClient::Impl::LookupMmappedFile(MEMFD_TYPE store_fd_val) {
+uint8_t *PlasmaClientImpl::LookupMmappedFile(MEMFD_TYPE store_fd_val) {
   auto entry = mmap_table_.find(store_fd_val);
   RAY_CHECK(entry != mmap_table_.end());
   return entry->second->pointer();
 }
 
-bool PlasmaClient::Impl::IsInUse(const ObjectID &object_id) {
+bool PlasmaClientImpl::IsInUse(const ObjectID &object_id) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   const auto elem = objects_in_use_.find(object_id);
   return (elem != objects_in_use_.end());
 }
 
-void PlasmaClient::Impl::IncrementObjectCount(const ObjectID &object_id,
+void PlasmaClientImpl::IncrementObjectCount(const ObjectID &object_id,
                                               PlasmaObject *object, bool is_sealed) {
   // Increment the count of the object to track the fact that it is being used.
   // The corresponding decrement should happen in PlasmaClient::Release.
@@ -276,7 +274,7 @@ void PlasmaClient::Impl::IncrementObjectCount(const ObjectID &object_id,
   object_entry->count += 1;
 }
 
-Status PlasmaClient::Impl::HandleCreateReply(const ObjectID &object_id,
+Status PlasmaClientImpl::HandleCreateReply(const ObjectID &object_id,
                                              const uint8_t *metadata,
                                              uint64_t *retry_with_request_id,
                                              std::shared_ptr<Buffer> *data) {
@@ -333,7 +331,7 @@ Status PlasmaClient::Impl::HandleCreateReply(const ObjectID &object_id,
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::CreateAndSpillIfNeeded(
+Status PlasmaClientImpl::CreateAndSpillIfNeeded(
     const ObjectID &object_id, const ray::rpc::Address &owner_address, int64_t data_size,
     const uint8_t *metadata, int64_t metadata_size, std::shared_ptr<Buffer> *data,
     fb::ObjectSource source, int device_num) {
@@ -362,7 +360,7 @@ Status PlasmaClient::Impl::CreateAndSpillIfNeeded(
   return status;
 }
 
-Status PlasmaClient::Impl::RetryCreate(const ObjectID &object_id, uint64_t request_id,
+Status PlasmaClientImpl::RetryCreate(const ObjectID &object_id, uint64_t request_id,
                                        const uint8_t *metadata,
                                        uint64_t *retry_with_request_id,
                                        std::shared_ptr<Buffer> *data) {
@@ -371,7 +369,7 @@ Status PlasmaClient::Impl::RetryCreate(const ObjectID &object_id, uint64_t reque
   return HandleCreateReply(object_id, metadata, retry_with_request_id, data);
 }
 
-Status PlasmaClient::Impl::TryCreateImmediately(
+Status PlasmaClientImpl::TryCreateImmediately(
     const ObjectID &object_id, const ray::rpc::Address &owner_address, int64_t data_size,
     const uint8_t *metadata, int64_t metadata_size, std::shared_ptr<Buffer> *data,
     fb::ObjectSource source, int device_num) {
@@ -385,7 +383,7 @@ Status PlasmaClient::Impl::TryCreateImmediately(
   return HandleCreateReply(object_id, metadata, nullptr, data);
 }
 
-Status PlasmaClient::Impl::GetBuffers(
+Status PlasmaClientImpl::GetBuffers(
     const ObjectID *object_ids, int64_t num_objects, int64_t timeout_ms,
     const std::function<std::shared_ptr<Buffer>(
         const ObjectID &, const std::shared_ptr<Buffer> &)> &wrap_buffer,
@@ -497,7 +495,7 @@ Status PlasmaClient::Impl::GetBuffers(
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::Get(const std::vector<ObjectID> &object_ids,
+Status PlasmaClientImpl::Get(const std::vector<ObjectID> &object_ids,
                                int64_t timeout_ms, std::vector<ObjectBuffer> *out,
                                bool is_from_worker) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
@@ -512,7 +510,7 @@ Status PlasmaClient::Impl::Get(const std::vector<ObjectID> &object_ids,
                     is_from_worker);
 }
 
-Status PlasmaClient::Impl::MarkObjectUnused(const ObjectID &object_id) {
+Status PlasmaClientImpl::MarkObjectUnused(const ObjectID &object_id) {
   auto object_entry = objects_in_use_.find(object_id);
   RAY_CHECK(object_entry != objects_in_use_.end());
   RAY_CHECK(object_entry->second->count == 0);
@@ -522,7 +520,7 @@ Status PlasmaClient::Impl::MarkObjectUnused(const ObjectID &object_id) {
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::Release(const ObjectID &object_id) {
+Status PlasmaClientImpl::Release(const ObjectID &object_id) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   // If the client is already disconnected, ignore release requests.
@@ -549,7 +547,7 @@ Status PlasmaClient::Impl::Release(const ObjectID &object_id) {
 }
 
 // This method is used to query whether the plasma store contains an object.
-Status PlasmaClient::Impl::Contains(const ObjectID &object_id, bool *has_object) {
+Status PlasmaClientImpl::Contains(const ObjectID &object_id, bool *has_object) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   // Check if we already have a reference to the object.
@@ -570,7 +568,7 @@ Status PlasmaClient::Impl::Contains(const ObjectID &object_id, bool *has_object)
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::Seal(const ObjectID &object_id) {
+Status PlasmaClientImpl::Seal(const ObjectID &object_id) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   // Make sure this client has a reference to the object before sending the
@@ -600,7 +598,7 @@ Status PlasmaClient::Impl::Seal(const ObjectID &object_id) {
   return Release(object_id);
 }
 
-Status PlasmaClient::Impl::Abort(const ObjectID &object_id) {
+Status PlasmaClientImpl::Abort(const ObjectID &object_id) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
   auto object_entry = objects_in_use_.find(object_id);
   RAY_CHECK(object_entry != objects_in_use_.end())
@@ -627,7 +625,7 @@ Status PlasmaClient::Impl::Abort(const ObjectID &object_id) {
   return ReadAbortReply(buffer.data(), buffer.size(), &id);
 }
 
-Status PlasmaClient::Impl::Delete(const std::vector<ObjectID> &object_ids) {
+Status PlasmaClientImpl::Delete(const std::vector<ObjectID> &object_ids) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   std::vector<ObjectID> not_in_use_ids;
@@ -653,7 +651,7 @@ Status PlasmaClient::Impl::Delete(const std::vector<ObjectID> &object_ids) {
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::Evict(int64_t num_bytes, int64_t &num_bytes_evicted) {
+Status PlasmaClientImpl::Evict(int64_t num_bytes, int64_t &num_bytes_evicted) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   // Send a request to the store to evict objects.
@@ -664,7 +662,7 @@ Status PlasmaClient::Impl::Evict(int64_t num_bytes, int64_t &num_bytes_evicted) 
   return ReadEvictReply(buffer.data(), buffer.size(), num_bytes_evicted);
 }
 
-Status PlasmaClient::Impl::Connect(const std::string &store_socket_name,
+Status PlasmaClientImpl::Connect(const std::string &store_socket_name,
                                    const std::string &manager_socket_name,
                                    int release_delay, int num_retries) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
@@ -681,7 +679,7 @@ Status PlasmaClient::Impl::Connect(const std::string &store_socket_name,
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::Disconnect() {
+Status PlasmaClientImpl::Disconnect() {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   // NOTE: We purposefully do not finish sending release calls for objects in
@@ -694,7 +692,7 @@ Status PlasmaClient::Impl::Disconnect() {
   return Status::OK();
 }
 
-std::string PlasmaClient::Impl::DebugString() {
+std::string PlasmaClientImpl::DebugString() {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
   if (!SendGetDebugStringRequest(store_conn_).ok()) {
     return "error sending request";
@@ -713,7 +711,7 @@ std::string PlasmaClient::Impl::DebugString() {
 // ----------------------------------------------------------------------
 // PlasmaClient
 
-PlasmaClient::PlasmaClient() : impl_(std::make_shared<PlasmaClient::Impl>()) {}
+PlasmaClient::PlasmaClient() : impl_(std::make_shared<PlasmaClientImpl>()) {}
 
 PlasmaClient::~PlasmaClient() {}
 

--- a/src/ray/object_manager/plasma/vineyard_client_impl.cc
+++ b/src/ray/object_manager/plasma/vineyard_client_impl.cc
@@ -46,60 +46,43 @@ VineyardClientImpl::VineyardClientImpl() : store_capacity_(0), client_() {}
 
 VineyardClientImpl::~VineyardClientImpl() {}
 
-// TODO
-bool VineyardClientImpl::IsInUse(const ObjectID &object_id) {
-  RAY_LOG(INFO) << "MENGKE: " << "check object in use, currently do nothing";
-  return true;
-}
-
-//TODO how to store metadata
 Status VineyardClientImpl::CreateAndSpillIfNeeded(
     const ObjectID &object_id, const ray::rpc::Address &owner_address, int64_t data_size,
     const uint8_t *metadata, int64_t metadata_size, std::shared_ptr<Buffer> *data,
     fb::ObjectSource source, int device_num) {
 
-  RAY_LOG(INFO) << "MENGKE: " << "Create a Buffer, currently no spilling";
-
   std::string bin_oid = object_id.Binary();
   vineyard::ExternalID external_id = vineyard::base64_encode(bin_oid);
-
-  RAY_LOG(INFO) << "MENGKE: " << "CreateBlobWithExternalData " << data_size << ", " << metadata_size;
-  RAY_LOG(INFO) << "MENGKE: " << object_id << " in " << external_id;
 
   std::unique_ptr<vineyard::BlobWriter> blob;
   VINEYARD_CHECK_OK( client_.CreateBlobExternal(data_size + metadata_size, external_id, metadata_size, blob) );
 
   *data = std::make_shared<PlasmaMutableBuffer>(shared_from_this(), reinterpret_cast<uint8_t*>(blob->data()), data_size);
+  //TODO(mengke): enable spilling
 
   // The metadata should come right after the data.
   if (metadata != NULL) {
     memcpy((*data)->Data() + data_size, metadata, metadata_size);
   }
 
-  uint8_t* dbg = (*data)->Data();
-  for(auto j = data_size; j < data_size + metadata_size; ++j) {
-    RAY_LOG(INFO) << "MENGKEMETA: " << dbg[j];
-  }
-
-  RAY_LOG(INFO) << "MENGKE: " << "Create a buffer with size: " << data_size << " " << metadata_size;
+  RAY_LOG(INFO) << "VINEYARD: " << "Create a buffer with size: " << data_size << " " << metadata_size;
   return Status::OK();
 }
 
-//TODO
 Status VineyardClientImpl::TryCreateImmediately(
     const ObjectID &object_id, const ray::rpc::Address &owner_address, int64_t data_size,
     const uint8_t *metadata, int64_t metadata_size, std::shared_ptr<Buffer> *data,
     fb::ObjectSource source, int device_num) {
-  RAY_LOG(INFO) << "MENGKE: " << "TryCreateImmediately, currently do nothing";
+  RAY_LOG(INFO) << "VINEYARD: " << "TryCreateImmediately, currently do nothing";
+ //TODO(mengke): implement TryCreateImmediately with Create
   return Status::OK();
 }
 
 
-//TODO
 Status VineyardClientImpl::Get(const std::vector<ObjectID> &object_ids,
                                int64_t timeout_ms, std::vector<ObjectBuffer> *out,
                                bool is_from_worker) {
-  RAY_LOG(INFO) << "MENGKE: " << "get objects form vineyard";
+  RAY_LOG(INFO) << "VINEYARD: " << "get objects form vineyard";
 
   const auto wrap_buffer = [=](const ObjectID &object_id,
                                const std::shared_ptr<Buffer> &buffer) {
@@ -128,13 +111,6 @@ Status VineyardClientImpl::Get(const std::vector<ObjectID> &object_ids,
     uint8_t* data =const_cast<uint8_t*>(arrow_buffer->data());
     size_t metadata_size = payload.external_size;
     size_t data_size = arrow_buffer->size() - metadata_size;
-    RAY_LOG(INFO) << "MENGKE: " << "Get object " <<  object_ids[i] << " - " <<  eids[i] << " data_size: " << data_size << " meta_size: " << metadata_size;
-    for(size_t j = 0; j < data_size; ++j) {
-      RAY_LOG(INFO) << "MENGKEDATA: " <<  data[j];
-    }
-    for(auto j = data_size; j < data_size + metadata_size; ++j) {
-      RAY_LOG(INFO) << "MENGKEMETA: " <<  data[j];
-    }
 
     std::shared_ptr<Buffer> physical_buf;
     physical_buf = std::make_shared<SharedMemoryBuffer>(data, data_size + metadata_size);
@@ -146,68 +122,75 @@ Status VineyardClientImpl::Get(const std::vector<ObjectID> &object_ids,
     object_buffers[i].device_num = 0;
   }
 
-  RAY_LOG(INFO) << "MENGKE: " << "Get objects done ";
   return Status::OK();
 }
 
-//TODO
 Status VineyardClientImpl::Release(const ObjectID &object_id) {
-  RAY_LOG(INFO) << "MENGKE: " << "get objects form vineyard";
+  RAY_LOG(INFO) << "VINEYARD: " << "Release objects in vineyard";
+  std::string bin_oid = object_id.Binary();
+  vineyard::ExternalID external_id = vineyard::base64_encode(bin_oid);
+  VINEYARD_CHECK_OK(client_.Release(external_id));
   return Status::OK();
 }
 
-// This method is used to query whether the plasma store contains an object.
-// TODO
 Status VineyardClientImpl::Contains(const ObjectID &object_id, bool *has_object) {
 
-  RAY_LOG(INFO) << "MENGKE: " << "check the existence of one given object in vineyard, currently not supported, cause panic";
+  RAY_LOG(INFO) << "VINEYARD: " << "check the existence of one given object in vineyard";
+  std::string bin_oid = object_id.Binary();
+  vineyard::ExternalID external_id = vineyard::base64_encode(bin_oid);
+  VINEYARD_CHECK_OK(client_.Exists(external_id));
   return Status::Invalid("Not supported.");
 }
 
-//TODO
 Status VineyardClientImpl::Seal(const ObjectID &object_id) {
-  RAY_LOG(INFO) << "MENGKE: " << "Seal the object in vineyard";
+  RAY_LOG(INFO) << "VINEYARD: " << "Seal the object in vineyard";
+  // already sealed in creation.
   return Status::OK();
 }
 
-//TODO
 Status VineyardClientImpl::Abort(const ObjectID &object_id) {
-  RAY_LOG(INFO) << "MENGKE: " << "Abort object, currently not supported, cause panic";
+  RAY_LOG(INFO) << "VINEYARD: " << "Abort object, currently not supported";
+  //TODO(mengke): client_.Abort(Externalid);
   return Status::Invalid("Not supported.");
 }
 
-//TODO
 Status VineyardClientImpl::Delete(const std::vector<ObjectID> &object_ids) {
-  RAY_LOG(INFO) << "MENGKE: " << "Delete objects, currently not supported";
+  RAY_LOG(INFO) << "VINEYARD: " << "Delete objects, currently not supported";
+  for
   return Status::OK();
 }
 
-//TODO
 Status VineyardClientImpl::Evict(int64_t num_bytes, int64_t &num_bytes_evicted) {
-  RAY_LOG(INFO) << "MENGKE: " << "evict some objects, currently not supported";
+  RAY_LOG(INFO) << "VINEYARD: " << "evict some objects, currently not supported";
+  //TODO(mengke): implement evict policy in vineyard.
   return Status::OK();
 }
 
-//TODO remember to stop the plasma server
 Status VineyardClientImpl::Connect(const std::string &store_socket_name,
                                    const std::string &manager_socket_name,
                                    int release_delay, int num_retries) {
-  RAY_LOG(INFO) << "MENGKE: " << "conected to Vineyard : " << store_socket_name;
+  RAY_LOG(INFO) << "VINEYARD: " << "conected to Vineyard : " << store_socket_name;
   const std::string dbg_socket_name = "/var/run/vineyard.sock";
   VINEYARD_CHECK_OK(client_.Connect(dbg_socket_name));
-  RAY_LOG(INFO) << "MENGKE: " << "conected done ";
+  RAY_LOG(INFO) << "VINEYARD: " << "conected done ";
   return Status::OK();
 }
 
-//TODO
 Status VineyardClientImpl::Disconnect() {
-  RAY_LOG(INFO) << "MENGKE: " << "disconnect to vineyard, currently do nothing";
+  RAY_LOG(INFO) << "VINEYARD: " << "disconnect to vineyard, currently do nothing";
+  //TODO(mengke): add disconnect in vineyard
   return Status::OK();
 }
 
-//TODO
+bool VineyardClientImpl::IsInUse(const ObjectID &object_id) {
+  RAY_LOG(INFO) << "VINEYARD: " << "check object in use, currently do nothing";
+  // TODO(mengke): implement the in-use map
+  return true;
+}
+
 std::string VineyardClientImpl::DebugString() {
-  RAY_LOG(INFO) << "MENGKE: " << "get debugstring from vineyard, currently do nothing.";
+  RAY_LOG(INFO) << "VINEYARD: " << "get debugstring from vineyard, currently do nothing.";
+  //TODO(mengke): 
   return std::string("No comments");
 }
 

--- a/src/ray/object_manager/plasma/vineyard_client_impl.cc
+++ b/src/ray/object_manager/plasma/vineyard_client_impl.cc
@@ -1,0 +1,214 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ray/object_manager/plasma/vineyard_client_impl.h"
+
+#include <cstring>
+
+#include <algorithm>
+#include <deque>
+#include <mutex>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <vineyard/client/client.h>
+#include <vineyard/client/ds/blob.h>
+#include <vineyard/client/ds/object_meta.h>
+#include <vineyard/common/util/base64.h>
+
+#include "ray/common/asio/instrumented_io_context.h"
+#include "ray/common/ray_config.h"
+
+namespace fb = plasma::flatbuf;
+
+namespace plasma {
+
+using fb::MessageType;
+using fb::PlasmaError;
+
+VineyardClientImpl::VineyardClientImpl() : store_capacity_(0), client_() {}
+
+VineyardClientImpl::~VineyardClientImpl() {}
+
+// TODO
+bool VineyardClientImpl::IsInUse(const ObjectID &object_id) {
+  RAY_LOG(INFO) << "MENGKE: " << "check object in use, currently do nothing";
+  return true;
+}
+
+//TODO how to store metadata
+Status VineyardClientImpl::CreateAndSpillIfNeeded(
+    const ObjectID &object_id, const ray::rpc::Address &owner_address, int64_t data_size,
+    const uint8_t *metadata, int64_t metadata_size, std::shared_ptr<Buffer> *data,
+    fb::ObjectSource source, int device_num) {
+
+  RAY_LOG(INFO) << "MENGKE: " << "Create a Buffer, currently no spilling";
+
+  std::string bin_oid = object_id.Binary();
+  vineyard::ExternalID external_id = vineyard::base64_encode(bin_oid);
+
+  RAY_LOG(INFO) << "MENGKE: " << "CreateBlobWithExternalData " << data_size << ", " << metadata_size;
+  RAY_LOG(INFO) << "MENGKE: " << object_id << " in " << external_id;
+
+  std::unique_ptr<vineyard::BlobWriter> blob;
+  VINEYARD_CHECK_OK( client_.CreateBlobExternal(data_size + metadata_size, external_id, metadata_size, blob) );
+
+  *data = std::make_shared<PlasmaMutableBuffer>(shared_from_this(), reinterpret_cast<uint8_t*>(blob->data()), data_size);
+
+  // The metadata should come right after the data.
+  if (metadata != NULL) {
+    memcpy((*data)->Data() + data_size, metadata, metadata_size);
+  }
+
+  uint8_t* dbg = (*data)->Data();
+  for(auto j = data_size; j < data_size + metadata_size; ++j) {
+    RAY_LOG(INFO) << "MENGKEMETA: " << dbg[j];
+  }
+
+  RAY_LOG(INFO) << "MENGKE: " << "Create a buffer with size: " << data_size << " " << metadata_size;
+  return Status::OK();
+}
+
+//TODO
+Status VineyardClientImpl::TryCreateImmediately(
+    const ObjectID &object_id, const ray::rpc::Address &owner_address, int64_t data_size,
+    const uint8_t *metadata, int64_t metadata_size, std::shared_ptr<Buffer> *data,
+    fb::ObjectSource source, int device_num) {
+  RAY_LOG(INFO) << "MENGKE: " << "TryCreateImmediately, currently do nothing";
+  return Status::OK();
+}
+
+
+//TODO
+Status VineyardClientImpl::Get(const std::vector<ObjectID> &object_ids,
+                               int64_t timeout_ms, std::vector<ObjectBuffer> *out,
+                               bool is_from_worker) {
+  RAY_LOG(INFO) << "MENGKE: " << "get objects form vineyard";
+
+  const auto wrap_buffer = [=](const ObjectID &object_id,
+                               const std::shared_ptr<Buffer> &buffer) {
+    return std::make_shared<PlasmaBuffer>(shared_from_this(), object_id, buffer);
+  };
+  const int64_t num_objects = object_ids.size();
+
+  std::vector<vineyard::ExternalID> eids;
+  for(auto object_id: object_ids) {
+    std::string bin_oid = object_id.Binary();
+    vineyard::ExternalID external_id = vineyard::base64_encode(bin_oid);
+    eids.emplace_back(external_id);
+  }
+
+  *out = std::vector<ObjectBuffer>(num_objects);
+  std::map<vineyard::ExternalID, vineyard::Payload> payloads;
+  std::map<vineyard::ExternalID, std::shared_ptr<arrow::Buffer>> buffers;
+  client_.GetBlobsByExternal(std::set<vineyard::ExternalID>(eids.begin(), eids.end()), payloads, buffers);
+
+  ObjectBuffer* object_buffers = &(*out)[0];
+
+  for (int64_t i = 0; i < num_objects; ++i) {
+
+    std::shared_ptr<arrow::Buffer> arrow_buffer = buffers.find(eids[i])->second;
+    vineyard::Payload payload = payloads.find(eids[i])->second;
+    uint8_t* data =const_cast<uint8_t*>(arrow_buffer->data());
+    size_t metadata_size = payload.external_size;
+    size_t data_size = arrow_buffer->size() - metadata_size;
+    RAY_LOG(INFO) << "MENGKE: " << "Get object " <<  object_ids[i] << " - " <<  eids[i] << " data_size: " << data_size << " meta_size: " << metadata_size;
+    for(size_t j = 0; j < data_size; ++j) {
+      RAY_LOG(INFO) << "MENGKEDATA: " <<  data[j];
+    }
+    for(auto j = data_size; j < data_size + metadata_size; ++j) {
+      RAY_LOG(INFO) << "MENGKEMETA: " <<  data[j];
+    }
+
+    std::shared_ptr<Buffer> physical_buf;
+    physical_buf = std::make_shared<SharedMemoryBuffer>(data, data_size + metadata_size);
+    physical_buf = wrap_buffer(object_ids[i], physical_buf);
+
+    object_buffers[i].data = SharedMemoryBuffer::Slice(physical_buf, 0, data_size);
+    object_buffers[i].metadata = SharedMemoryBuffer::Slice(
+          physical_buf, data_size, metadata_size);
+    object_buffers[i].device_num = 0;
+  }
+
+  RAY_LOG(INFO) << "MENGKE: " << "Get objects done ";
+  return Status::OK();
+}
+
+//TODO
+Status VineyardClientImpl::Release(const ObjectID &object_id) {
+  RAY_LOG(INFO) << "MENGKE: " << "get objects form vineyard";
+  return Status::OK();
+}
+
+// This method is used to query whether the plasma store contains an object.
+// TODO
+Status VineyardClientImpl::Contains(const ObjectID &object_id, bool *has_object) {
+
+  RAY_LOG(INFO) << "MENGKE: " << "check the existence of one given object in vineyard, currently not supported, cause panic";
+  return Status::Invalid("Not supported.");
+}
+
+//TODO
+Status VineyardClientImpl::Seal(const ObjectID &object_id) {
+  RAY_LOG(INFO) << "MENGKE: " << "Seal the object in vineyard";
+  return Status::OK();
+}
+
+//TODO
+Status VineyardClientImpl::Abort(const ObjectID &object_id) {
+  RAY_LOG(INFO) << "MENGKE: " << "Abort object, currently not supported, cause panic";
+  return Status::Invalid("Not supported.");
+}
+
+//TODO
+Status VineyardClientImpl::Delete(const std::vector<ObjectID> &object_ids) {
+  RAY_LOG(INFO) << "MENGKE: " << "Delete objects, currently not supported";
+  return Status::OK();
+}
+
+//TODO
+Status VineyardClientImpl::Evict(int64_t num_bytes, int64_t &num_bytes_evicted) {
+  RAY_LOG(INFO) << "MENGKE: " << "evict some objects, currently not supported";
+  return Status::OK();
+}
+
+//TODO remember to stop the plasma server
+Status VineyardClientImpl::Connect(const std::string &store_socket_name,
+                                   const std::string &manager_socket_name,
+                                   int release_delay, int num_retries) {
+  RAY_LOG(INFO) << "MENGKE: " << "conected to Vineyard : " << store_socket_name;
+  const std::string dbg_socket_name = "/var/run/vineyard.sock";
+  VINEYARD_CHECK_OK(client_.Connect(dbg_socket_name));
+  RAY_LOG(INFO) << "MENGKE: " << "conected done ";
+  return Status::OK();
+}
+
+//TODO
+Status VineyardClientImpl::Disconnect() {
+  RAY_LOG(INFO) << "MENGKE: " << "disconnect to vineyard, currently do nothing";
+  return Status::OK();
+}
+
+//TODO
+std::string VineyardClientImpl::DebugString() {
+  RAY_LOG(INFO) << "MENGKE: " << "get debugstring from vineyard, currently do nothing.";
+  return std::string("No comments");
+}
+
+}  // namespace plasma

--- a/src/ray/object_manager/plasma/vineyard_client_impl.h
+++ b/src/ray/object_manager/plasma/vineyard_client_impl.h
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <vineyard/client/client.h>
+
+#include "ray/common/buffer.h"
+#include "ray/common/status.h"
+#include "ray/object_manager/plasma/common.h"
+#include "ray/util/visibility.h"
+#include "src/ray/protobuf/common.pb.h"
+
+#include "ray/object_manager/plasma/client.h"
+
+#include "absl/container/flat_hash_map.h"
+
+namespace plasma {
+
+
+class VineyardClientImpl : public IPlasmaClientImpl, 
+                           public std::enable_shared_from_this<VineyardClientImpl> {
+ public:
+  VineyardClientImpl();
+  ~VineyardClientImpl();
+
+ // IPlasmaClientImpl method implementations
+
+  Status Connect(const std::string &store_socket_name,
+                 const std::string &manager_socket_name, int release_delay = 0,
+                 int num_retries = -1) override;
+
+  Status CreateAndSpillIfNeeded(const ObjectID &object_id,
+                                const ray::rpc::Address &owner_address, int64_t data_size,
+                                const uint8_t *metadata, int64_t metadata_size,
+                                std::shared_ptr<Buffer> *data, plasma::flatbuf::ObjectSource source,
+                                int device_num = 0) override;
+
+  Status TryCreateImmediately(const ObjectID &object_id,
+                              const ray::rpc::Address &owner_address, int64_t data_size,
+                              const uint8_t *metadata, int64_t metadata_size,
+                              std::shared_ptr<Buffer> *data, plasma::flatbuf::ObjectSource source,
+                              int device_num) override;
+
+  Status Get(const std::vector<ObjectID> &object_ids, int64_t timeout_ms,
+             std::vector<ObjectBuffer> *object_buffers, bool is_from_worker) override;
+
+  Status Release(const ObjectID &object_id) override;
+
+  Status Contains(const ObjectID &object_id, bool *has_object) override;
+
+  Status Abort(const ObjectID &object_id) override;
+
+  Status Seal(const ObjectID &object_id) override;
+
+  Status Delete(const std::vector<ObjectID> &object_ids) override;
+
+  Status Evict(int64_t num_bytes, int64_t &num_bytes_evicted) override;
+
+  Status Disconnect() override;
+
+  std::string DebugString() override;
+
+  bool IsInUse(const ObjectID &object_id) override;
+
+  int64_t store_capacity() override { return store_capacity_; }
+ private:
+  int64_t store_capacity_;
+  vineyard::Client client_;
+};
+
+}  // namespace plasma


### PR DESCRIPTION
This is a proposal to enhance ray object-store.

### Ray Component

plasma

### Motivation:

Ray is a general-purpose and powerful computing framework and makes it simple to scale any compute-intensive Python workload. By storing the objects in Plasma, data can be efficiently (0-copy) shared between Ray tasks. We propose to provide a plasma-like object store with more functionalities target for different situations (e.g. to better support [[Kubernetes](https://kubernetes.io/zh/)](https://kubernetes.io/zh/)). In other words, we can simultaneously have multiple plasma object-store variants with different functionalities. (e.g. users can choose a variant at `ray.init()`)

[**[Vineyard](https://github.com/v6d-io/v6d)**](https://github.com/v6d-io/v6d) is also an in-memory immutable data manager that provides out-of-the-box high-level abstraction and zero-copy in-memory sharing for distributed data in big data tasks. It aims to optimize the end-to-end performance of complex data analytics jobs on cloud platforms. It manages various data structures produced in the job, and cross-system data sharing can be conducted without serialization/deserialization overheads by decoupling metadata and data payloads.

**Opportunities**: Vineyard can enhance the ray object store with more functionalities for modern data-intensive applications. To be specific, the benefits are four-fold:

- O1: Sharing data with systems out of Ray. Vineyard is a daemon in cluster that any system can put/get objects into/from it.
- O2: Composability. Objects will not be sealed twice when we create a new object form a existing one(e.g. add a new column for data frame)
- O3: Zero copy in put/get. Objects can be directly created in object store without copying or serialization.
- O4: Reusable Routines (IO/Chunking/Partitions)

**At the first step, we only focus on the O1**. Specifically speaking, Plasma store is currently an internal component of raylet, it shares the same fate with raylet. For systems that are not integrated with ray, they can not share objects via Plasma, thus have to share them by filesystem which will inevitably introduce heavy overheads if their data are complex (e.g. serializing a graph cost a long time.). While vineyard serves as a daemon in kubernete cluster.

### Proposal

To make the integration maintainable and clear, the change will only happen in plasma client. Here we may add a virtual class for specific store client to inherit. we propose to: (1) first expose the interface of plasma client, this will not change any logic of raylet (2) then add a new client implementation for that interface (e.g. vineyard client). Since the vineyard provides similar APIs as Plasma, the client implementation here may just wrap the request and forward to vineyard server instead of plasma server.

**Step 1: Expose the interface (for third-party object store client)**. Make the `PlasmaClientImpl` to inherit the `IPlasmaClientImpl`. By defining the required ability of a store client, allow other object stores (.e.g vineyard) to act like a plasma mock. In this step, we will not add or delete anything into raylet.

```c++
class IPlasmaClientImpl{
 public:
  // connect to the store server
  virtual Status Connect(const std::string &store_socket_name,
                 const std::string &manager_socket_name, int release_delay = 0,
                 int num_retries = -1) = 0;
  // create a blob with given size.
  virtual Status CreateAndSpillIfNeeded(const ObjectID &object_id,
                                const ray::rpc::Address &owner_address, int64_t data_size,
                                const uint8_t *metadata, int64_t metadata_size,
                                std::shared_ptr<Buffer> *data, plasma::flatbuf::ObjectSource source, int device_num = 0) = 0;
  // create a blob immediately for some clients that can't wait.
  virtual Status TryCreateImmediately(const ObjectID &object_id, int64_t data_size,
                              const uint8_t *metadata, int64_t metadata_size,
                              std::shared_ptr<Buffer> *data, plasma::flatbuf::ObjectSource source, int device_num) = 0;

  // get objects by object_ids.
  virtual Status Get(const std::vector<ObjectID> &object_ids, int64_t timeout_ms,
             std::vector<ObjectBuffer> *object_buffers, bool is_from_worker) = 0;

  // notify the server that this client does not need the object.
  virtual Status Release(const ObjectID &object_id) = 0;

  // check the existence
  virtual Status Contains(const ObjectID &object_id, bool *has_object) = 0;

  // Abort an unsealed object as if it was never created at all.
  virtual Status Abort(const ObjectID &object_id) = 0;

  // Seal the object, make it immutable.
  virtual Status Seal(const ObjectID &object_id) = 0;

  // Delete the objects only when (1) they exist, (2) has been sealed, (3) not used by any clients. or it will do nothing.
  virtual Status Delete(const std::vector<ObjectID> &object_ids) = 0;

  // Delete objects until we have freed up num_bytes bytes.
  virtual Status Evict(int64_t num_bytes, int64_t &num_bytes_evicted) = 0;

  // disconnect from the store server.
  virtual Status Disconnect() = 0;

  // query the capacity of the object store.
  virtual int64_t store_capacity() = 0;
};
```

**Step 2: Vineyard implement the interface as a plasma alternative.** Like Plasma, Vineyard also has client-side and server-side. The client slide provides Plasma-compatible APIs which facilitates us to wrap Plasma requests into Vineyard requests. Thus we implement `VineyardClientImpl` in a separate file. Both `PlasmaClientImpl` and `VineyardClientImpl` inherit from the `IPlasmaClientImpl`, which allow users to select the desired client(Plasma or Vineyard) at runtime.

### Use Cases

To share the objects with out-of-Ray systems, vineyard provides API to persist a Ray object into an object that external systems can recognize(e.g. vineyard object in this proposal). The conversion should be zero-copy. The conversion APIs are provided by vineyard.

```python
# users get objects from ray then put (zero-copy) them into vineyard or vice versa.
import ray
import vineyard as v6d

ray.init(object_store="vineyard")

ray_data = [1,2,3,4]
ray_object_ref = ray.put(y)
ray_object = ray.get(object_ref)

v6d_object_id = v6d.from_ray(ray_object_ref) # 0-copy
# now the object is visable to systems out of ray.
print(v6d.get(v6d_object_id)) # [1,2,3,4]
```

### Anything else

**Eviction**. Eviction is implemented in different object store variants (server-side). The goal of eviction is to free needless objects to make space for new objects. The eviction policy may be different in different store variants, servers can only evict the objects that are not needed by clients (a.k.a.reference count = 0). Currently, the policies of Plasma and Vineyard are both based on LRU.

**Spillings**. When creating a new object with insufficient memory even with evicting possible objects, the local object manager will try to spill objects to external storage. The code path of spilling is out of Plasma thus we can reuse it in third-party object-store.